### PR TITLE
Correct runId in workflow URL

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 module.exports = ({context, core}) => {
-    let workflowURL = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.run_id}`;
+    let workflowURL = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
     let status = core.getInput("status");
     core.debug(`Computed workflow URL: ${workflowURL}`);
     let color;


### PR DESCRIPTION
The current url is generating an `undefined` here. When testing locally, this was assumed to be an artifact of how `act` runs a workflow.

This did not bear out when published to GitHub. I believe act still doesn't define one.