### PR TITLE
Migrate GitHub Actions updates from TSCCR to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: "weekly"
     # Only update hashicorp-owned actions
     # External actions managed via TSCCR
-    allow:
-      - dependency-name: "hashicorp/*"
     groups:
       github-actions-breaking:
         update-types:


### PR DESCRIPTION
This repository previously had GitHub Actions updates managed through the [TSCCR automation system](https://github.com/hashicorp/security-tsccr/blob/main/tsccr-helper/help/automation.md). As TSCCR is no longer being maintained, responsibility for managing GitHub Actions updates now falls to the repository's owners.

This PR enhances your Dependabot configuration by adding the GitHub Actions ecosystem. The configuration is aligned with the previous TSCCR automation approach and will ensure your GitHub Actions continue to receive important updates.

Please note that this is a one-time configuration change. After merging, Dependabot will automatically manage GitHub Actions updates according to the specified schedule.

For additional information, please refer to [Memo SEC-032](https://docs.google.com/document/d/1bvwk8yNEakgPWG5l7pKPpwwrgXnNLdMIDpMZ-TSEJo4). If you have any questions, the [#team-prodsec](https://hashicorp.enterprise.slack.com/archives/C010VJT0FRP) team in Slack would be happy to help.

**Compliance remark**
The work is tracked by @hashicorp/team-prodsec  in [PSP-2640](https://hashicorp.atlassian.net/browse/PSP-2640)

[PSP-2640]: https://hashicorp.atlassian.net/browse/PSP-2640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ